### PR TITLE
Support both ash 0.27.1 and 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ travis-ci = { repository = "gwihlidal/vk-mem-rs" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ash = "0.27.1"
+ash = ">= 0.27.1, <= 0.28.0"
 bitflags = "1.0.4"
 failure = "0.1.5"
 


### PR DESCRIPTION
The library works both with the ash 0.27.1 and the newly released 0.28.0. And instead of forcing a specific version and I added this range dependency to increase compatibility and allow the user of the library to use either version