### PR TITLE
Add windows-gnu to build.rs, and add cross-compilation information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ and add this to your crate root:
 extern crate vk_mem;
 ```
 
+## Compiling using MinGW W64
+
+Vulkan Memory Allocator requires C++11 threads.
+MinGW W64 does not support these by default, so you need to switch to the posix build.
+For example, on debian you need to run the following:
+
+```bash
+update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
+update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
+update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
+```
+
 ## License
 
 Licensed under either of

--- a/build.rs
+++ b/build.rs
@@ -56,6 +56,16 @@ fn main() {
             .flag("-Wno-reorder")
             .cpp_link_stdlib("stdc++")
             .cpp(true);
+    } else if target.contains("windows") && target.contains("gnu") {
+        build
+            .flag("-std=c++11")
+            .flag("-Wno-missing-field-initializers")
+            .flag("-Wno-unused-variable")
+            .flag("-Wno-unused-parameter")
+            .flag("-Wno-unused-private-field")
+            .flag("-Wno-reorder")
+            .cpp_link_stdlib("stdc++")
+            .cpp(true);
     }
 
     build.compile("vma_cpp");


### PR DESCRIPTION
This fixes cross-compile builds using MinGW W64