### PR TITLE
Remove the parallel feature for cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bitflags = "1.0.4"
 failure = "0.1.5"
 
 [build-dependencies]
-cc = { version = "1.0.35", features = ["parallel"] }
+cc = "1.0.35"
 
 [build-dependencies.bindgen]
 version = "0.49.0"


### PR DESCRIPTION
There's only a single file being compiled by the build script so there isn't really any need for parallelism. Removing the parallel feature prevents rayon and it's dependencies from being included and actually builds slightly faster.
