### PR TITLE
Allow the failure crate to be disabled through a feature toggle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,6 @@ matrix:
 
 script:
 - cargo build --all --verbose
+- cargo build --all --verbose --no-default-features
 #- cargo test --all --verbose
 - cargo doc --all --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 ash = ">= 0.27.1"
 bitflags = "1.0.4"
-failure = "0.1.5"
+failure = { version = "0.1.5", optional = true }
 
 [build-dependencies]
 cc = { version = "1.0.35", features = ["parallel"] }
@@ -46,5 +46,6 @@ opt-level = 3
 codegen-units = 1
 
 [features]
+default = ["failure"]
 generate_bindings=["bindgen"]
 link_vulkan=[]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate ash;
 #[macro_use]
 extern crate bitflags;
+#[cfg(feature = "failure")]
 extern crate failure;
 
 pub mod error;


### PR DESCRIPTION
Allows the failure crate and its dependencies to be optional.