### PR TITLE
Add a way to cleanup Allocator without dropping it.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1906,15 +1906,24 @@ impl Allocator {
         }
         Ok(())
     }
+
+    /// Destroys the internal allocator instance. After this has been called,
+    /// no other functions may be called. Useful for ensuring a specific destruction
+    /// order (for example, if an Allocator is a member of something that owns the Vulkan
+    /// instance and destroys it in its own Drop).
+    pub fn cleanup(&mut self) {
+        if !self.internal.is_null() {
+            unsafe {
+                ffi::vmaDestroyAllocator(self.internal);
+                self.internal = std::ptr::null_mut();
+            }
+        }
+    }
 }
 
 /// Custom `Drop` implementation to clean up internal allocation instance
 impl Drop for Allocator {
     fn drop(&mut self) {
-        if !self.internal.is_null() {
-            unsafe {
-                ffi::vmaDestroyAllocator(self.internal);
-            }
-        }
+        self.cleanup();
     }
 }


### PR DESCRIPTION
Perhaps not very Rusty, but what VK use is?

I need to destroy the allocator contents before I destroy the device, and it just gets really awkward to put the allocator in an Option<> and set it to None before destroy_device. This works around that.

I would also be open to other ideas, of course, if this isn't palatable.