### PR TITLE
Implement std::error::Error for vk_mem::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@
 use ash;
 #[cfg(feature = "failure")]
 use failure::{Backtrace, Context, Fail};
+#[cfg(not(feature = "failure"))]
+use std::error::Error as StdError;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::result;
@@ -65,6 +67,16 @@ impl Fail for Error {
 
     fn backtrace(&self) -> Option<&Backtrace> {
         self.ctx.backtrace()
+    }
+}
+
+#[cfg(not(feature = "failure"))]
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self.kind {
+            ErrorKind::Vulkan(ref err) => Some(err),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
Implementation for the `Error` trait of the std library.
`ash` also implements it, so it becomes quite handy being able to box the errors.