### PR TITLE
Implement vk_mem::Allocation::null() for symmetry with vk::Image::null() etc.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,14 @@ pub struct Allocation {
     pub(crate) internal: ffi::VmaAllocation,
 }
 
+impl Allocation {
+    pub fn null() -> Allocation {
+        Allocation {
+            internal: std::ptr::null_mut(),
+        }
+    }
+}
+
 unsafe impl Send for Allocation {}
 unsafe impl Sync for Allocation {}
 


### PR DESCRIPTION
Had a use for it (unfortunately) and `vk_mem::Allocation::null()` looks more ash-idiomatic than `vk_mem::Allocation { internal: std::ptr::null() }`.  (the latter doesn't even compile, it turns out)