### PR TITLE
Add Eq, Hash and further derive()s to enum MemoryUsage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,7 @@ fn pool_create_info_to_ffi(info: &AllocatorPoolCreateInfo) -> ffi::VmaPoolCreate
 }
 
 /// Intended usage of memory.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum MemoryUsage {
     /// No intended memory usage specified.
     /// Use other members of `AllocationCreateInfo` to specify your requirements.


### PR DESCRIPTION
All Ash enums have these (though they are implemented a bit differently), and I was replacing some direct Vulkan usage with VMA in our code when I hit a case where this would be convenient (was using it as a key in a hashmap).