### PR TITLE
Added copy to Allocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ impl Default for AllocatorPool {
 /// use `Allocator::get_allocation_info`.
 ///
 /// Some kinds allocations can be in lost state.
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Allocation {
     /// Pointer to internal VmaAllocation instance
     pub(crate) internal: ffi::VmaAllocation,


### PR DESCRIPTION
This compiles just fine and it's only a pointer, why not be able to Copy it?

Allows containing types to implement Copy and be used in structures like a slotmap.

Please educate me if this is a no-no :D

This is for issue #24 