### PR TITLE
Android support for build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -46,6 +46,16 @@ fn main() {
             .cpp_link_stdlib("c++")
             .cpp_set_stdlib("c++")
             .cpp(true);
+    } if target.contains("android") {
+        build
+            .flag("-std=c++11")
+            .flag("-Wno-missing-field-initializers")
+            .flag("-Wno-unused-variable")
+            .flag("-Wno-unused-parameter")
+            .flag("-Wno-unused-private-field")
+            .flag("-Wno-reorder")
+            .cpp_link_stdlib("c++")
+            .cpp(true);
     } else if target.contains("linux") {
         build
             .flag("-std=c++11")

--- a/build.rs
+++ b/build.rs
@@ -46,7 +46,7 @@ fn main() {
             .cpp_link_stdlib("c++")
             .cpp_set_stdlib("c++")
             .cpp(true);
-    } if target.contains("android") {
+    } else if target.contains("android") {
         build
             .flag("-std=c++11")
             .flag("-Wno-missing-field-initializers")


### PR DESCRIPTION
Currently `build.rs` doesn't have a case for android. I've added one.

(Tested and ran on android)