### PR TITLE
Remove Result for functions that are always Ok

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Removed `Result` return values from functions that always returned `Ok(())`
+
 ## 0.2.2 (2020-03-28)
 
 * Fixed Windows bindgen regression.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,11 +932,10 @@ impl Allocator {
     /// `AllocationCreateFlags::CAN_MAKE_OTHER_LOST` flags to inform the allocator when a new frame begins.
     /// Allocations queried using `Allocator::get_allocation_info` cannot become lost
     /// in the current frame.
-    pub fn set_current_frame_index(&self, frame_index: u32) -> Result<()> {
+    pub fn set_current_frame_index(&self, frame_index: u32) {
         unsafe {
             ffi::vmaSetCurrentFrameIndex(self.internal, frame_index);
         }
-        Ok(())
     }
 
     /// Retrieves statistics from current state of the `Allocator`.
@@ -1090,11 +1089,10 @@ impl Allocator {
     }
 
     /// Destroys `AllocatorPool` object and frees Vulkan device memory.
-    pub fn destroy_pool(&self, pool: &AllocatorPool) -> Result<()> {
+    pub fn destroy_pool(&self, pool: &AllocatorPool) {
         unsafe {
             ffi::vmaDestroyPool(self.internal, pool.internal);
         }
-        Ok(())
     }
 
     /// Retrieves statistics of existing `AllocatorPool` object.
@@ -1281,11 +1279,10 @@ impl Allocator {
 
     /// Frees memory previously allocated using `Allocator::allocate_memory`,
     /// `Allocator::allocate_memory_for_buffer`, or `Allocator::allocate_memory_for_image`.
-    pub fn free_memory(&self, allocation: &Allocation) -> Result<()> {
+    pub fn free_memory(&self, allocation: &Allocation) {
         unsafe {
             ffi::vmaFreeMemory(self.internal, allocation.internal);
         }
-        Ok(())
     }
 
     /// Frees memory and destroys multiple allocations.
@@ -1297,7 +1294,7 @@ impl Allocator {
     /// It may be internally optimized to be more efficient than calling 'Allocator::free_memory` `allocations.len()` times.
     ///
     /// Allocations in 'allocations' slice can come from any memory pools and types.
-    pub fn free_memory_pages(&self, allocations: &[Allocation]) -> Result<()> {
+    pub fn free_memory_pages(&self, allocations: &[Allocation]) {
         let mut allocations_ffi: Vec<ffi::VmaAllocation> =
             allocations.iter().map(|x| x.internal).collect();
         unsafe {
@@ -1307,7 +1304,6 @@ impl Allocator {
                 allocations_ffi.as_mut_ptr(),
             );
         }
-        Ok(())
     }
 
     /// Tries to resize an allocation in place, if there is enough free memory after it.
@@ -1401,9 +1397,8 @@ impl Allocator {
         &self,
         allocation: &Allocation,
         user_data: *mut ::std::os::raw::c_void,
-    ) -> Result<()> {
+    ) {
         ffi::vmaSetAllocationUserData(self.internal, allocation.internal, user_data);
-        Ok(())
     }
 
     /// Creates new allocation that is in lost state from the beginning.
@@ -1469,11 +1464,10 @@ impl Allocator {
     }
 
     /// Unmaps memory represented by given allocation, mapped previously using `Allocator::map_memory`.
-    pub fn unmap_memory(&self, allocation: &Allocation) -> Result<()> {
+    pub fn unmap_memory(&self, allocation: &Allocation) {
         unsafe {
             ffi::vmaUnmapMemory(self.internal, allocation.internal);
         }
-        Ok(())
     }
 
     /// Flushes memory of given allocation.
@@ -1485,12 +1479,7 @@ impl Allocator {
     /// - `offset` and `size` don't have to be aligned; hey are internally rounded down/up to multiple of `nonCoherentAtomSize`.
     /// - If `size` is 0, this call is ignored.
     /// - If memory type that the `allocation` belongs to is not `ash::vk::MemoryPropertyFlags::HOST_VISIBLE` or it is `ash::vk::MemoryPropertyFlags::HOST_COHERENT`, this call is ignored.
-    pub fn flush_allocation(
-        &self,
-        allocation: &Allocation,
-        offset: usize,
-        size: usize,
-    ) -> Result<()> {
+    pub fn flush_allocation(&self, allocation: &Allocation, offset: usize, size: usize) {
         unsafe {
             ffi::vmaFlushAllocation(
                 self.internal,
@@ -1499,7 +1488,6 @@ impl Allocator {
                 size as ffi::VkDeviceSize,
             );
         }
-        Ok(())
     }
 
     /// Invalidates memory of given allocation.
@@ -1511,12 +1499,7 @@ impl Allocator {
     /// - `offset` and `size` don't have to be aligned. They are internally rounded down/up to multiple of `nonCoherentAtomSize`.
     /// - If `size` is 0, this call is ignored.
     /// - If memory type that the `allocation` belongs to is not `ash::vk::MemoryPropertyFlags::HOST_VISIBLE` or it is `ash::vk::MemoryPropertyFlags::HOST_COHERENT`, this call is ignored.
-    pub fn invalidate_allocation(
-        &self,
-        allocation: &Allocation,
-        offset: usize,
-        size: usize,
-    ) -> Result<()> {
+    pub fn invalidate_allocation(&self, allocation: &Allocation, offset: usize, size: usize) {
         unsafe {
             ffi::vmaInvalidateAllocation(
                 self.internal,
@@ -1525,7 +1508,6 @@ impl Allocator {
                 size as ffi::VkDeviceSize,
             );
         }
-        Ok(())
     }
 
     /// Checks magic number in margins around all allocations in given memory types (in both default and custom pools) in search for corruptions.
@@ -1850,7 +1832,7 @@ impl Allocator {
     /// ```
     ///
     /// It it safe to pass null as `buffer` and/or `allocation`.
-    pub fn destroy_buffer(&self, buffer: ash::vk::Buffer, allocation: &Allocation) -> Result<()> {
+    pub fn destroy_buffer(&self, buffer: ash::vk::Buffer, allocation: &Allocation) {
         unsafe {
             ffi::vmaDestroyBuffer(
                 self.internal,
@@ -1858,7 +1840,6 @@ impl Allocator {
                 allocation.internal,
             );
         }
-        Ok(())
     }
 
     /// This function automatically creates an image, allocates appropriate memory
@@ -1920,7 +1901,7 @@ impl Allocator {
     /// ```
     ///
     /// It it safe to pass null as `image` and/or `allocation`.
-    pub fn destroy_image(&self, image: ash::vk::Image, allocation: &Allocation) -> Result<()> {
+    pub fn destroy_image(&self, image: ash::vk::Image, allocation: &Allocation) {
         unsafe {
             ffi::vmaDestroyImage(
                 self.internal,
@@ -1928,7 +1909,6 @@ impl Allocator {
                 allocation.internal,
             );
         }
-        Ok(())
     }
 
     /// Destroys the internal allocator instance. After this has been called,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -179,7 +179,7 @@ fn create_gpu_buffer() {
         )
         .unwrap();
     assert_eq!(allocation_info.get_mapped_data(), std::ptr::null_mut());
-    allocator.destroy_buffer(buffer, &allocation).unwrap();
+    allocator.destroy_buffer(buffer, &allocation);
 }
 
 #[test]
@@ -206,7 +206,7 @@ fn create_cpu_buffer_preferred() {
         )
         .unwrap();
     assert_ne!(allocation_info.get_mapped_data(), std::ptr::null_mut());
-    allocator.destroy_buffer(buffer, &allocation).unwrap();
+    allocator.destroy_buffer(buffer, &allocation);
 }
 
 #[test]
@@ -245,8 +245,8 @@ fn create_gpu_buffer_pool() {
         .create_buffer(&buffer_info, &allocation_info)
         .unwrap();
     assert_ne!(allocation_info.get_mapped_data(), std::ptr::null_mut());
-    allocator.destroy_buffer(buffer, &allocation).unwrap();
-    allocator.destroy_pool(&pool).unwrap();
+    allocator.destroy_buffer(buffer, &allocation);
+    allocator.destroy_pool(&pool);
 }
 
 #[test]
@@ -281,7 +281,7 @@ fn test_gpu_stats() {
     assert_eq!(stats_2.total.allocationCount, 1);
     assert_eq!(stats_2.total.usedBytes, 16 * 1024);
 
-    allocator.destroy_buffer(buffer, &allocation).unwrap();
+    allocator.destroy_buffer(buffer, &allocation);
 
     let stats_3 = allocator.calculate_stats().unwrap();
     assert_eq!(stats_3.total.blockCount, 1);
@@ -318,7 +318,7 @@ fn test_stats_string() {
     assert!(stats_2.len() > 0);
     assert_ne!(stats_1, stats_2);
 
-    allocator.destroy_buffer(buffer, &allocation).unwrap();
+    allocator.destroy_buffer(buffer, &allocation);
 
     let stats_3 = allocator.build_stats_string(true).unwrap();
     assert!(stats_3.len() > 0);


### PR DESCRIPTION
We had a bunch of redundant error handling in our renderer that was needed before this due to this crate returning `Result<()>` for a lot of functions that didn't have any failure conditions. 

This wasn't very ergonomic to work with and it is not ideal to handle errors that can never happen, so this PR removes `Result` return values for vk-mem functions that returned void.

One could argue that more functions that return simple structs and values also here don't need to return it through a `Result<value>` if this crate always returns `Ok` on it, but chose to just do it for the simple void functions here which was the most obvious ones.