### PR TITLE
Update GPU Open Update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This crate provides an FFI layer and idiomatic rust wrappers for the excellent A
 - [VMA GitHub](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator)
 - [VMA Documentation](https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/)
 - [GPU Open Announce](https://gpuopen.com/gaming-product/vulkan-memory-allocator/)
-- [GPU Open Update](https://gpuopen.com/vulkan-memory-allocator-2-1/)
+- [GPU Open Update](https://gpuopen.com/vulkan-memory-allocator-2-3-0/)
 
 ## Problem
 


### PR DESCRIPTION
The recent GPU Open website redesign seems to have shifted URLs around. The old URL no longer worked, so this change updates it to point to the VMA 2.3 announcement blog post instead. It was the only other VMA update blog post I saw on the site.