### PR TITLE
Replace mem::zeroed() in AllocatorCreateInfo::default()

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -53,8 +53,7 @@ impl TestHarness {
             .engine_version(0)
             .api_version(ash::vk::make_version(1, 0, 0));
 
-        let layer_names =
-            [::std::ffi::CString::new("VK_LAYER_KHRONOS_validation").unwrap()];
+        let layer_names = [::std::ffi::CString::new("VK_LAYER_KHRONOS_validation").unwrap()];
         let layers_names_raw: Vec<*const i8> = layer_names
             .iter()
             .map(|raw_name| raw_name.as_ptr())

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -159,6 +159,11 @@ fn create_allocator() {
 }
 
 #[test]
+fn default_allocator_create_info() {
+    let _ = vk_mem::AllocatorCreateInfo::default();
+}
+
+#[test]
 fn create_gpu_buffer() {
     let harness = TestHarness::new();
     let allocator = harness.create_allocator();

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -54,7 +54,7 @@ impl TestHarness {
             .api_version(ash::vk::make_version(1, 0, 0));
 
         let layer_names =
-            [::std::ffi::CString::new("VK_LAYER_LUNARG_standard_validation").unwrap()];
+            [::std::ffi::CString::new("VK_LAYER_KHRONOS_validation").unwrap()];
         let layers_names_raw: Vec<*const i8> = layer_names
             .iter()
             .map(|raw_name| raw_name.as_ptr())


### PR DESCRIPTION
Fixes an issue when compiling with Rust nightly. Calling `AllocatorCreateInfo::default()` results in: 
```
panicked at 'attempted to zero-initialize type `ash::Device`, which is invalid
```

Fixes #19

