### PR TITLE
Add a recording feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ codegen-units = 1
 default = []
 generate_bindings=["bindgen"]
 link_vulkan=[]
+recording=[]

--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,10 @@ fn main() {
     //#define VMA_DEBUG_MARGIN 16
     //#define VMA_DEBUG_DETECT_CORRUPTION 1
     //#define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
-    //#define VMA_RECORDING_ENABLED 0
     //#define VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY 256
+
+    #[cfg(feature = "recording")]
+    build.define("VMA_RECORDING_ENABLED", "1");
 
     // Add the files we build
     let source_files = ["wrapper/vma_lib.cpp"];


### PR DESCRIPTION
This patch allows defining `VMA_RECORDING_ENABLED` in the build script using a `recording` feature, to enable the record/replay functionality.

[Here is the allocator create info struct field that should work after enabling the feature](https://docs.rs/vk-mem/0.2.2/vk_mem/ffi/struct.VmaAllocatorCreateInfo.html#structfield.pRecordSettings)

Side note: Thank you for creating this crate! I've been using it in my renderer with no issues so far. Really good work