### PR TITLE
Define VMA_DYNAMIC_VULKAN_FUNCTIONS as 0. Closes #42.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,11 @@ fn main() {
     // Linux (pkconfig) and Windows (VULKAN_SDK environment variable).
     build.define("VMA_STATIC_VULKAN_FUNCTIONS", "0");
 
+    // This prevents VMA from trying to fetch any remaining pointers
+    // that are still null after using the loader in ash, which can
+    // cause linker errors.
+    build.define("VMA_DYNAMIC_VULKAN_FUNCTIONS", "0");
+
     // TODO: Add some configuration options under crate features
     //#define VMA_HEAVY_ASSERT(expr) assert(expr)
     //#define VMA_USE_STL_CONTAINERS 1


### PR DESCRIPTION
Based on the discussion on #42 this should fix the errors on master. I found the docs for this setting [here](https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/configuration.html) under the `Pointers to Vulkan functions` section.  If you'd prefer, I can also make this a feature flag and a default feature so that it can be opted out of.

I believe this will resolve issues #42 #45 #46 and #47 

Thanks again for your work on this crate, it really is excellent!