### PR TITLE
AllocatorCreateInfo taking ownership of device and instance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,9 +869,7 @@ impl Allocator {
             )
         });
         match result {
-            ash::vk::Result::SUCCESS => Ok(Allocator {
-                internal,
-            }),
+            ash::vk::Result::SUCCESS => Ok(Allocator { internal }),
             _ => Err(Error::vulkan(result)),
         }
     }


### PR DESCRIPTION
Currently in AllocatorCreateInfo we're required to pass in an owned `device` and `instance`. These objects are huge - each with a size of a few kilobytes. If we want to retain the `device` and `instance` objects outside the allocator, they needs to be cloned at least twice.

This PR changes this so that AllocatorCreateInfo will only take a reference of the device and instance objects, saving two unnecessary clones.
