### PR TITLE
Fix ash 0.33.0 compatibility issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ extern crate failure;
 pub mod error;
 pub mod ffi;
 pub use crate::error::{Error, ErrorKind, Result};
-use ash::{version::InstanceV1_0, vk::Handle};
+use ash::vk::Handle;
 use std::mem;
 
 /// Main allocator object
@@ -768,7 +768,6 @@ pub struct DefragmentationStats {
 impl Allocator {
     /// Constructor a new `Allocator` using the provided options.
     pub fn new(create_info: &AllocatorCreateInfo) -> Result<Self> {
-        use ash::version::{DeviceV1_0, DeviceV1_1};
         let instance = create_info.instance.clone();
         let device = create_info.device.clone();
         let routed_functions = unsafe {


### PR DESCRIPTION
ash 0.33.0 removed the `version` module in [this commit](https://github.com/MaikKlein/ash/commit/f5e7cfe89651e9c498918a98c9a47fc01f77b959#diff-3adc4b835bf1dfdf0a10d32290602a8d3b51711aca3a8fc61516b746ebd38370), so this pull request removes references to the obsolete module.
