### PR TITLE
Support ash 0.32 and 0.33, toggled by feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,9 @@ travis-ci = { repository = "gwihlidal/vk-mem-rs" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ash = ">= 0.27.1"
+ash_32 = { version = ">= 0.27.1, < 0.33", package = "ash", optional = true }
+ash_33 = { version = "0.33", package = "ash", optional = true }
+ash_latest = { version = ">= 0.33", package = "ash", optional = true }
 bitflags = "1.2.1"
 failure = { version = "0.1.7", optional = true }
 
@@ -46,7 +48,7 @@ opt-level = 3
 codegen-units = 1
 
 [features]
-default = []
+default = ["ash_33"]
 generate_bindings=["bindgen"]
 link_vulkan=[]
 recording=[]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use ash;
+use crate::ash;
 #[cfg(feature = "failure")]
 use failure::{Backtrace, Context, Fail};
 #[cfg(not(feature = "failure"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,13 @@
 
 #![allow(invalid_value)]
 
-extern crate ash;
+#[cfg(feature = "ash_32")]
+pub use ash_32 as ash;
+#[cfg(feature = "ash_33")]
+pub use ash_33 as ash;
+#[cfg(feature = "ash_latest")]
+pub use ash_latest as ash;
+
 #[macro_use]
 extern crate bitflags;
 #[cfg(feature = "failure")]
@@ -11,7 +17,9 @@ extern crate failure;
 pub mod error;
 pub mod ffi;
 pub use crate::error::{Error, ErrorKind, Result};
-use ash::{version::InstanceV1_0, vk::Handle};
+#[cfg(feature = "ash_32")]
+use ash::version::InstanceV1_0;
+use ash::vk::Handle;
 use std::mem;
 
 /// Main allocator object
@@ -768,6 +776,7 @@ pub struct DefragmentationStats {
 impl Allocator {
     /// Constructor a new `Allocator` using the provided options.
     pub fn new(create_info: &AllocatorCreateInfo) -> Result<Self> {
+        #[cfg(feature = "ash_32")]
         use ash::version::{DeviceV1_0, DeviceV1_1};
         let instance = create_info.instance.clone();
         let device = create_info.device.clone();


### PR DESCRIPTION
This shows how both 0.32 and 0.33 (and future ash versions) can be supported at the same time via feature flags. This also allows people to opt-into non-semver reference to 0.33, which may be useful when people want to use latest, but this crate has not republished against the future version yet. (I used this approach for referencing winit in a different project, the idea came from the imgui crate).

Related to #54
Minimal build fix also PR'd as #56