### PR TITLE
ash-0.33-build-fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ extern crate failure;
 pub mod error;
 pub mod ffi;
 pub use crate::error::{Error, ErrorKind, Result};
-use ash::{version::InstanceV1_0, vk::Handle};
+use ash::vk::Handle;
 use std::mem;
 
 /// Main allocator object
@@ -768,7 +768,6 @@ pub struct DefragmentationStats {
 impl Allocator {
     /// Constructor a new `Allocator` using the provided options.
     pub fn new(create_info: &AllocatorCreateInfo) -> Result<Self> {
-        use ash::version::{DeviceV1_0, DeviceV1_1};
         let instance = create_info.instance.clone();
         let device = create_info.device.clone();
         let routed_functions = unsafe {


### PR DESCRIPTION
I haven't tested this in an actual binary drawing anything, but it fixes the build.

See also #54 and #55. (The other PR is a more complicated approach that would allow supporting 0.32 and 0.33 simultaneously and allow using a semver reference to ash, but still allow opting into latest ash.)
