### PR TITLE
bump ash to 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = { repository = "gwihlidal/vk-mem-rs" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ash = { version = "0.37", default-features = false }
+ash = { version = "0.38", default-features = false }
 bitflags = "2.4"
 
 [build-dependencies]

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -387,7 +387,7 @@ bitflags! {
 }
 
 pub struct AllocatorCreateInfo<'a> {
-    pub(crate) inner: ffi::VmaAllocatorCreateInfo,
+    pub(crate) inner: ffi::VmaAllocatorCreateInfo<'a>,
     pub(crate) physical_device: PhysicalDevice,
     pub(crate) device: &'a Device,
     pub(crate) instance: &'a Instance,
@@ -741,7 +741,7 @@ pub struct VirtualAllocationCreateInfo {
 
 /// Parameters of created VirtualBlock, to be passed to VirtualBlock::new()
 pub struct VirtualBlockCreateInfo<'a> {
-    pub(crate) inner: ffi::VmaVirtualBlockCreateInfo,
+    pub(crate) inner: ffi::VmaVirtualBlockCreateInfo<'a>,
     pub(crate) _phantom_data: PhantomData<&'a u8>,
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -549,7 +549,7 @@ pub struct VmaVulkanFunctions {
 }
 #[doc = " Description of a Allocator to be created."]
 #[repr(C)]
-pub struct VmaAllocatorCreateInfo {
+pub struct VmaAllocatorCreateInfo<'a> {
     #[doc = " Flags for created allocator. Use #VmaAllocatorCreateFlagBits enum."]
     pub flags: VmaAllocatorCreateFlags,
     #[doc = " Vulkan physical device."]
@@ -563,7 +563,7 @@ pub struct VmaAllocatorCreateInfo {
     pub preferredLargeHeapBlockSize: DeviceSize,
     #[doc = " Custom CPU memory allocation callbacks. Optional."]
     #[doc = "** Optional, can be null. When specified, will also be used for all CPU-side memory allocations. */"]
-    pub pAllocationCallbacks: *const AllocationCallbacks,
+    pub pAllocationCallbacks: *const AllocationCallbacks<'a>,
     #[doc = " Informative callbacks for `vkAllocateMemory`, `vkFreeMemory`. Optional."]
     #[doc = "** Optional, can be null. */"]
     pub pDeviceMemoryCallbacks: *const VmaDeviceMemoryCallbacks,
@@ -986,7 +986,7 @@ pub struct VmaDefragmentationStats {
 }
 #[doc = " Parameters of created #VmaVirtualBlock object to be passed to vmaCreateVirtualBlock()."]
 #[repr(C)]
-pub struct VmaVirtualBlockCreateInfo {
+pub struct VmaVirtualBlockCreateInfo<'a> {
     #[doc = " \\brief Total size of the virtual block."]
     #[doc = ""]
     #[doc = "Sizes can be expressed in bytes or any units you want as long as you are consistent in using them."]
@@ -997,7 +997,7 @@ pub struct VmaVirtualBlockCreateInfo {
     #[doc = " \\brief Custom CPU memory allocation callbacks. Optional."]
     #[doc = ""]
     #[doc = "Optional, can be null. When specified, they will be used for all CPU-side memory allocations."]
-    pub pAllocationCallbacks: *const AllocationCallbacks,
+    pub pAllocationCallbacks: *const AllocationCallbacks<'a>,
 }
 #[doc = " Parameters of created virtual allocation to be passed to vmaVirtualAllocate()."]
 #[repr(C)]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,12 +1,12 @@
 extern crate ash;
 extern crate vk_mem;
 
-use ash::{extensions::ext::DebugUtils, vk};
+use ash::{ext::debug_utils, vk};
 use std::{os::raw::c_void, sync::Arc};
 use vk_mem::Alloc;
 
 fn extension_names() -> Vec<*const i8> {
-    vec![DebugUtils::name().as_ptr()]
+    vec![debug_utils::NAME.as_ptr()]
 }
 
 unsafe extern "system" fn vulkan_debug_callback(
@@ -29,7 +29,7 @@ pub struct TestHarness {
     pub device: ash::Device,
     pub physical_device: ash::vk::PhysicalDevice,
     pub debug_callback: ash::vk::DebugUtilsMessengerEXT,
-    pub debug_report_loader: ash::extensions::ext::DebugUtils,
+    pub debug_report_loader: debug_utils::Instance,
 }
 
 impl Drop for TestHarness {
@@ -46,7 +46,7 @@ impl Drop for TestHarness {
 impl TestHarness {
     pub fn new() -> Self {
         let app_name = ::std::ffi::CString::new("vk-mem testing").unwrap();
-        let app_info = ash::vk::ApplicationInfo::builder()
+        let app_info = ash::vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(0)
             .engine_name(&app_name)
@@ -60,7 +60,7 @@ impl TestHarness {
             .collect();
 
         let extension_names_raw = extension_names();
-        let create_info = ash::vk::InstanceCreateInfo::builder()
+        let create_info = ash::vk::InstanceCreateInfo::default()
             .application_info(&app_info)
             .enabled_layer_names(&layers_names_raw)
             .enabled_extension_names(&extension_names_raw);
@@ -72,7 +72,7 @@ impl TestHarness {
                 .expect("Instance creation error")
         };
 
-        let debug_info = ash::vk::DebugUtilsMessengerCreateInfoEXT::builder()
+        let debug_info = ash::vk::DebugUtilsMessengerCreateInfoEXT::default()
             .message_severity(
                 ash::vk::DebugUtilsMessageSeverityFlagsEXT::ERROR
                     | ash::vk::DebugUtilsMessageSeverityFlagsEXT::WARNING,
@@ -84,7 +84,7 @@ impl TestHarness {
             )
             .pfn_user_callback(Some(vulkan_debug_callback));
 
-        let debug_report_loader = DebugUtils::new(&entry, &instance);
+        let debug_report_loader = debug_utils::Instance::new(&entry, &instance);
         let debug_callback = unsafe {
             debug_report_loader
                 .create_debug_utils_messenger(&debug_info, None)
@@ -113,13 +113,12 @@ impl TestHarness {
 
         let priorities = [1.0];
 
-        let queue_info = [ash::vk::DeviceQueueCreateInfo::builder()
+        let queue_info = [ash::vk::DeviceQueueCreateInfo::default()
             .queue_family_index(0)
-            .queue_priorities(&priorities)
-            .build()];
+            .queue_priorities(&priorities)];
 
         let device_create_info =
-            ash::vk::DeviceCreateInfo::builder().queue_create_infos(&queue_info);
+            ash::vk::DeviceCreateInfo::default().queue_create_infos(&queue_info);
 
         let device: ash::Device = unsafe {
             instance
@@ -167,13 +166,10 @@ fn create_gpu_buffer() {
     unsafe {
         let (buffer, mut allocation) = allocator
             .create_buffer(
-                &ash::vk::BufferCreateInfo::builder()
-                    .size(16 * 1024)
-                    .usage(
-                        ash::vk::BufferUsageFlags::VERTEX_BUFFER
-                            | ash::vk::BufferUsageFlags::TRANSFER_DST,
-                    )
-                    .build(),
+                &ash::vk::BufferCreateInfo::default().size(16 * 1024).usage(
+                    ash::vk::BufferUsageFlags::VERTEX_BUFFER
+                        | ash::vk::BufferUsageFlags::TRANSFER_DST,
+                ),
                 &allocation_info,
             )
             .unwrap();
@@ -197,13 +193,10 @@ fn create_cpu_buffer_preferred() {
     unsafe {
         let (buffer, mut allocation) = allocator
             .create_buffer(
-                &ash::vk::BufferCreateInfo::builder()
-                    .size(16 * 1024)
-                    .usage(
-                        ash::vk::BufferUsageFlags::VERTEX_BUFFER
-                            | ash::vk::BufferUsageFlags::TRANSFER_DST,
-                    )
-                    .build(),
+                &ash::vk::BufferCreateInfo::default().size(16 * 1024).usage(
+                    ash::vk::BufferUsageFlags::VERTEX_BUFFER
+                        | ash::vk::BufferUsageFlags::TRANSFER_DST,
+                ),
                 &allocation_info,
             )
             .unwrap();
@@ -219,10 +212,9 @@ fn create_gpu_buffer_pool() {
     let allocator = harness.create_allocator();
     let allocator = Arc::new(allocator);
 
-    let buffer_info = ash::vk::BufferCreateInfo::builder()
+    let buffer_info = ash::vk::BufferCreateInfo::default()
         .size(16 * 1024)
-        .usage(ash::vk::BufferUsageFlags::UNIFORM_BUFFER | ash::vk::BufferUsageFlags::TRANSFER_DST)
-        .build();
+        .usage(ash::vk::BufferUsageFlags::UNIFORM_BUFFER | ash::vk::BufferUsageFlags::TRANSFER_DST);
 
     let allocation_info = vk_mem::AllocationCreateInfo {
         required_flags: ash::vk::MemoryPropertyFlags::HOST_VISIBLE,
@@ -269,13 +261,10 @@ fn test_gpu_stats() {
 
         let (buffer, mut allocation) = allocator
             .create_buffer(
-                &ash::vk::BufferCreateInfo::builder()
-                    .size(16 * 1024)
-                    .usage(
-                        ash::vk::BufferUsageFlags::VERTEX_BUFFER
-                            | ash::vk::BufferUsageFlags::TRANSFER_DST,
-                    )
-                    .build(),
+                &ash::vk::BufferCreateInfo::default().size(16 * 1024).usage(
+                    ash::vk::BufferUsageFlags::VERTEX_BUFFER
+                        | ash::vk::BufferUsageFlags::TRANSFER_DST,
+                ),
                 &allocation_info,
             )
             .unwrap();


### PR DESCRIPTION
Hi!

ash released a new breaking version (0.38). This PR bumps the version of ash.