### PR TITLE
Improve safety docs on `Allocator::new()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ unsafe impl Sync for Allocation {}
 
 impl Allocator {
     /// Construct a new `Allocator` using the provided options.
-    /// Safety: [`AllocatorCreateInfo::instance`], [`AllocatorCreateInfo::device`] and
+    ///
+    /// # Safety
+    /// [`AllocatorCreateInfo::instance`], [`AllocatorCreateInfo::device`] and
     /// [`AllocatorCreateInfo::physical_device`] must be valid throughout the lifetime of the allocator.
     pub unsafe fn new(create_info: AllocatorCreateInfo) -> VkResult<Self> {
         unsafe extern "system" fn get_instance_proc_addr_stub(


### PR DESCRIPTION
Safety documentation typically lives under a (linkable and anchored) header to be easier to discover, rather than crammed on the same line/paragraph as the documentation because of a missing newline and the `Safety:` "announcement" being regular text. Fix that with some markdown.