### PR TITLE
Derive `Clone` and `Copy` for `Allocation`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ unsafe impl Sync for Allocator {}
 /// use `Allocator::get_allocation_info`.
 ///
 /// Some kinds allocations can be in lost state.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Allocation(ffi::VmaAllocation);
 unsafe impl Send for Allocation {}
 unsafe impl Sync for Allocation {}


### PR DESCRIPTION
Thanks a bunch for the useful crate!

It looks like `Allocation` was both `Clone` and `Copy` after #25, but the derives were removed in 869e532ca0ec70a99e3463141c354759d99e1e74 when `Allocation` was changed to a type alias.