### PR TITLE
Add get Allocation::get_allocation_info2 API call

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -688,6 +688,39 @@ impl From<ffi::VmaAllocationInfo> for AllocationInfo {
     }
 }
 
+/// Extended parameters of a VmaAllocation object that can be retrieved using `Allocation::get_allocation_info2`.
+#[derive(Debug, Clone)]
+pub struct AllocationInfo2 {
+    /// Basic parameters of the allocation.
+    /// 
+    /// If you need only these, you can use function vmaGetAllocationInfo() and structure #VmaAllocationInfo instead.
+    pub allocation_info: AllocationInfo,
+    /// Size of the `VkDeviceMemory` block that the allocation belongs to.
+    /// 
+    /// In case of an allocation with dedicated memory, it will be equal to `allocationInfo.size`.
+    pub block_size: u64,
+    /// `true` if the allocation has dedicated memory, `false` if it was placed as part of a larger memory block.
+    /// 
+    /// When `true`, it also means `VkMemoryDedicatedAllocateInfo` was used when creating the allocation
+    /// (if VK_KHR_dedicated_allocation extension or Vulkan version >= 1.1 is enabled).
+    pub dedicated_memory: bool,
+}
+
+impl From<&ffi::VmaAllocationInfo2> for AllocationInfo2 {
+    fn from(info: &ffi::VmaAllocationInfo2) -> Self {
+        Self {
+            allocation_info: info.allocationInfo.into(),
+            block_size: info.blockSize,
+            dedicated_memory: info.dedicatedMemory != 0
+        }
+    }
+}
+impl From<ffi::VmaAllocationInfo2> for AllocationInfo2 {
+    fn from(info: ffi::VmaAllocationInfo2) -> Self {
+        (&info).into()
+    }
+}
+
 bitflags! {
     /// Flags for configuring `VirtualBlock` construction
     #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,19 @@ impl Allocator {
         }
     }
 
+    /// Returns extended information about specified allocation.
+    ///
+    /// Extended parameters in structure AllocationInfo2 include memory block size
+    /// and a flag telling whether the allocation has dedicated memory.
+    /// It can be useful e.g. for interop with OpenGL.
+    pub fn get_allocation_info2(&self, allocation: &Allocation) -> AllocationInfo2 {
+        unsafe {
+            let mut allocation_info: ffi::VmaAllocationInfo2 = mem::zeroed();
+            ffi::vmaGetAllocationInfo2(self.internal, allocation.0, &mut allocation_info);
+            allocation_info.into()
+        }
+    }
+
     /// Sets user data in given allocation to new value.
     ///
     /// If the allocation was created with `AllocationCreateFlags::USER_DATA_COPY_STRING`,


### PR DESCRIPTION
This adds an API call returning AllocationInfo2 struct

Useful for performing interop with cuda, etc.

Related VMA docs: https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/struct_vma_allocation_info2.html